### PR TITLE
Update alloc_netdev

### DIFF
--- a/nat64_netdev.c
+++ b/nat64_netdev.c
@@ -71,7 +71,7 @@ int nat64_netdev_create(struct net_device **dev, const char *name)
 {
 	int ret = 0;
 
-	*dev = alloc_netdev(0, name, nat64_netdev_setup);
+	*dev = alloc_netdev(0, name, NET_NAME_UNKNOWN, nat64_netdev_setup);
 
 	if (!*dev)
 		return -ENOMEM;


### PR DESCRIPTION
alloc_netdev now has 4 arguments, the third being the "name_assign_type"
the new definition is as follows:
`#define alloc_netdev(sizeof_priv, name, name_assign_type, setup)`

This allows compilation on modern linux systems